### PR TITLE
freeMemCount is not the free page count

### DIFF
--- a/free command/kalloc.c
+++ b/free command/kalloc.c
@@ -107,6 +107,13 @@ kalloc(void)
 void 
 freeMem()
 {
-  cprintf("Free  Used \n");
-  cprintf("%d  %d", freeMemCount, usedMemCount);
+cnt = 0;  
+  struct run *r;
+  r = kmem.freelist;
+  while((r = r->next))
+  cnt++;
+  //cprintf("Count is %d",cnt); 
+  total = cnt + usedMemCount;
+ cprintf("Free  Used Total\n");
+ cprintf("%d  %d %d \n", cnt*PGSIZE, usedMemCount*PGSIZE, total*PGSIZE);
 }


### PR DESCRIPTION
The total pages need to be counted in the linked list. That would give the free page count, and not the variable, freeMemCount, which only calculated the free pages within the range between *vstart and *vend. While printing, multiply with PGSIZE to get the output in the form of bytes and not in the form of number of pages, as earlier.